### PR TITLE
Separate rtos tick calc

### DIFF
--- a/development/applications/albus/include/albus.h
+++ b/development/applications/albus/include/albus.h
@@ -11,6 +11,10 @@
 
 #include <stdint.h>
 
+#define SYS_TICK_FREQ      1000
+#define MS_TO_TICKS(MS)    (MS)
+#define TICKS_TO_MS(ticks) (ticks)
+
 #define DISABLE_IRQ()        \
   uint32_t prim;             \
   prim = __get_PRIMASK();    \

--- a/development/applications/albus/src/main.c
+++ b/development/applications/albus/src/main.c
@@ -31,7 +31,7 @@ void delay_ms(uint32_t ms)
 void rtos_delay_ms(uint32_t ms)
 {
   if (os_started) {
-    vTaskDelay(ms);
+    vTaskDelay(MS_TO_TICKS(ms));
   }
   else {
     delay_ms(ms);

--- a/development/applications/common/falcon_common.h
+++ b/development/applications/common/falcon_common.h
@@ -9,10 +9,6 @@ void error_handler(void);
 #define FLN_OK  0
 #define FLN_ERR -1
 
-#define SYS_TICK_FREQ      1000
-#define MS_TO_TICKS(MS)    (MS)
-#define TICKS_TO_MS(ticks) (ticks)
-
 #define FLN_ERR_CHECK(x)    \
   do {                      \
     int retval = (x);       \

--- a/development/applications/hedwig/include/hedwig.h
+++ b/development/applications/hedwig/include/hedwig.h
@@ -23,6 +23,10 @@
 #define LED_STACK_SIZE               128
 #define FLIGHT_CONTROL_STACK_SIZE    512
 
+#define SYS_TICK_FREQ      1000
+#define MS_TO_TICKS(MS)    (MS)
+#define TICKS_TO_MS(ticks) (ticks)
+
 #define DISABLE_IRQ()        \
   uint32_t prim;             \
   prim = __get_PRIMASK();    \


### PR DESCRIPTION
Move rtos tick calc defines into separate target headers in case tick rates are different 